### PR TITLE
Update cumulusci.yml - add long-config dev org definition

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -34,3 +34,8 @@ flows:
     steps:
       3:
         task: load_dataset
+orgs:
+  scratch:
+    dev_long:
+      config_file: orgs/dev.json
+      days: 30


### PR DESCRIPTION

# Critical Changes

# Changes
Adds an option in CCI config to create dev scratch orgs with 30 days until expiration

# Issues Closed
