### PR TITLE
bump to API v61.0 and bump devDependencies

### DIFF
--- a/force-app/main/default/classes/FieldLabelController.cls-meta.xml
+++ b/force-app/main/default/classes/FieldLabelController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/FieldLabelController_Test.cls-meta.xml
+++ b/force-app/main/default/classes/FieldLabelController_Test.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/lwc/stickySelectronDataCell/stickySelectronDataCell.js-meta.xml
+++ b/force-app/main/default/lwc/stickySelectronDataCell/stickySelectronDataCell.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/stickySelectronMain/stickySelectronMain.js-meta.xml
+++ b/force-app/main/default/lwc/stickySelectronMain/stickySelectronMain.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Sticky Selectron</masterLabel>
     <targets>

--- a/force-app/main/default/lwc/stickySelectronSelectCell/stickySelectronSelectCell.js-meta.xml
+++ b/force-app/main/default/lwc/stickySelectronSelectCell/stickySelectronSelectCell.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
             "version": "1.0.0",
             "hasInstallScript": true,
             "devDependencies": {
-                "@lwc/eslint-plugin-lwc": "^1.8.1",
+                "@lwc/eslint-plugin-lwc": "^1.8.2",
                 "@prettier/plugin-xml": "^3.4.1",
-                "@salesforce/eslint-config-lwc": "^3.5.3",
+                "@salesforce/eslint-config-lwc": "^3.6.0",
                 "@salesforce/eslint-plugin-lightning": "^1.0.0",
-                "@salesforce/sfdx-lwc-jest": "^5.0.0",
+                "@salesforce/sfdx-lwc-jest": "^5.1.0",
                 "eslint": "^8.57.0",
                 "eslint-plugin-import": "^2.29.1",
                 "eslint-plugin-jest": "^28.6.0",
@@ -98,7 +98,6 @@
             "integrity": "sha512-SO5E3bVxDuxyNxM5agFv480YA2HO6ohZbGxbazZdIk3KQOPOGVNw6q78I9/lbviIf95eq6tPozeYnJLbjnC8IA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
                 "eslint-visitor-keys": "^2.1.0",
@@ -459,44 +458,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@babel/plugin-proposal-async-generator-functions": {
-            "version": "7.20.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.20.7.tgz",
-            "integrity": "sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==",
-            "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-async-generator-functions instead.",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-environment-visitor": "^7.18.9",
-                "@babel/helper-plugin-utils": "^7.20.2",
-                "@babel/helper-remap-async-to-generator": "^7.18.9",
-                "@babel/plugin-syntax-async-generators": "^7.8.4"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-class-properties": {
-            "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
-            "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
-            "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-create-class-features-plugin": "^7.18.6",
-                "@babel/helper-plugin-utils": "^7.18.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
         "node_modules/@babel/plugin-proposal-dynamic-import": {
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.18.6.tgz",
@@ -507,27 +468,6 @@
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.18.6",
                 "@babel/plugin-syntax-dynamic-import": "^7.8.3"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-proposal-object-rest-spread": {
-            "version": "7.20.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
-            "integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
-            "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/compat-data": "^7.20.5",
-                "@babel/helper-compilation-targets": "^7.20.7",
-                "@babel/helper-plugin-utils": "^7.20.2",
-                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-transform-parameters": "^7.20.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -756,16 +696,52 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
-        "node_modules/@babel/plugin-transform-async-to-generator": {
-            "version": "7.23.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.23.3.tgz",
-            "integrity": "sha512-A7LFsKi4U4fomjqXJlZg/u0ft/n8/7n7lpffUP/ZULx/DtV9SGlNKZolHH6PE8Xl1ngCc0M11OaeZptXVkfKSw==",
+        "node_modules/@babel/plugin-transform-async-generator-functions": {
+            "version": "7.24.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.24.3.tgz",
+            "integrity": "sha512-Qe26CMYVjpQxJ8zxM1340JFNjZaF+ISWpr1Kt/jGo+ZTUzKkfw/pphEWbRCb+lmSM6k/TOgfYLvmbHkUQ0asIg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.22.15",
-                "@babel/helper-plugin-utils": "^7.22.5",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-plugin-utils": "^7.24.0",
+                "@babel/helper-remap-async-to-generator": "^7.22.20",
+                "@babel/plugin-syntax-async-generators": "^7.8.4"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-async-to-generator": {
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.24.1.tgz",
+            "integrity": "sha512-AawPptitRXp1y0n4ilKcGbRYWfbbzFWz2NqNu7dacYDtFtz0CMjG64b3LQsb3KIgnf4/obcUL78hfaOS7iCUfw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.24.1",
+                "@babel/helper-plugin-utils": "^7.24.0",
                 "@babel/helper-remap-async-to-generator": "^7.22.20"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-class-properties": {
+            "version": "7.24.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.1.tgz",
+            "integrity": "sha512-OMLCXi0NqvJfORTaPQBwqLXHhb93wkBKZ4aNwMl6WtehO7ar+cmp+89iPEQPqxAnxsOKTaMcs3POz3rKayJ72g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-class-features-plugin": "^7.24.1",
+                "@babel/helper-plugin-utils": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -784,6 +760,25 @@
                 "@babel/helper-module-transforms": "^7.24.7",
                 "@babel/helper-plugin-utils": "^7.24.7",
                 "@babel/helper-simple-access": "^7.24.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-object-rest-spread": {
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.5.tgz",
+            "integrity": "sha512-7EauQHszLGM3ay7a161tTQH7fj+3vVM/gThlz5HpFtnygTxjrlvoeq7MPVA1Vy9Q555OB8SnAOsMkLShNkkrHA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-compilation-targets": "^7.23.6",
+                "@babel/helper-plugin-utils": "^7.24.5",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-transform-parameters": "^7.24.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -936,9 +931,9 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.10.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
-            "integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==",
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+            "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1981,15 +1976,15 @@
             }
         },
         "node_modules/@lwc/babel-plugin-component": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@lwc/babel-plugin-component/-/babel-plugin-component-6.5.0.tgz",
-            "integrity": "sha512-6BPdcOZe8CeyqgVTCDxrzce0b79lLOSxSHiz9gqJJld8LbJHj872Wq8BfFQg3yl81hDtNFlpsfUo7Oremz+OKA==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@lwc/babel-plugin-component/-/babel-plugin-component-6.7.2.tgz",
+            "integrity": "sha512-I9lYWCCt4tzeL6FGBrQxndvR8l5OaOt8sR6UebKAbksIePNMjSusEdOJdB6I+Q5muUD+zISZauXGggJbNkzLkA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "7.22.15",
-                "@lwc/errors": "6.5.0",
-                "@lwc/shared": "6.5.0",
+                "@babel/helper-module-imports": "7.24.3",
+                "@lwc/errors": "6.7.2",
+                "@lwc/shared": "6.7.2",
                 "line-column": "~1.0.2"
             },
             "peerDependencies": {
@@ -1997,55 +1992,56 @@
             }
         },
         "node_modules/@lwc/babel-plugin-component/node_modules/@babel/helper-module-imports": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-            "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+            "version": "7.24.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
+            "integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.22.15"
+                "@babel/types": "^7.24.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@lwc/compiler": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@lwc/compiler/-/compiler-6.5.0.tgz",
-            "integrity": "sha512-xO8LHoV77LQtE0QBUUwuOWgsxWCK/H3mxxgWeikuTCzoEhtzST+arrLovFwoto65bv+pzCRzcmFG2hZc3Atbdw==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@lwc/compiler/-/compiler-6.7.2.tgz",
+            "integrity": "sha512-ZD1dEGSU+eY2clLk2N0TRxFRD3XyDZQxlISm264jY3C8XR3E+i/FyTSCYkxtbhUK/KKlHo3J6KwKrcNIUh0vLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/core": "7.24.1",
-                "@babel/plugin-proposal-async-generator-functions": "7.20.7",
-                "@babel/plugin-proposal-class-properties": "7.18.6",
-                "@babel/plugin-proposal-object-rest-spread": "7.20.7",
-                "@babel/plugin-transform-async-to-generator": "7.23.3",
+                "@babel/core": "7.24.5",
+                "@babel/plugin-transform-async-generator-functions": "7.24.3",
+                "@babel/plugin-transform-async-to-generator": "7.24.1",
+                "@babel/plugin-transform-class-properties": "7.24.1",
+                "@babel/plugin-transform-object-rest-spread": "7.24.5",
                 "@locker/babel-plugin-transform-unforgeables": "0.20.0",
-                "@lwc/babel-plugin-component": "6.5.0",
-                "@lwc/errors": "6.5.0",
-                "@lwc/shared": "6.5.0",
-                "@lwc/style-compiler": "6.5.0",
-                "@lwc/template-compiler": "6.5.0"
+                "@lwc/babel-plugin-component": "6.7.2",
+                "@lwc/errors": "6.7.2",
+                "@lwc/shared": "6.7.2",
+                "@lwc/ssr-compiler": "6.7.2",
+                "@lwc/style-compiler": "6.7.2",
+                "@lwc/template-compiler": "6.7.2"
             }
         },
         "node_modules/@lwc/compiler/node_modules/@babel/core": {
-            "version": "7.24.1",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.1.tgz",
-            "integrity": "sha512-F82udohVyIgGAY2VVj/g34TpFUG606rumIHjTfVbssPg2zTR7PuuEpZcX8JA6sgBfIYmJrFtWgPvHQuJamVqZQ==",
+            "version": "7.24.5",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.5.tgz",
+            "integrity": "sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.24.1",
-                "@babel/generator": "^7.24.1",
+                "@babel/code-frame": "^7.24.2",
+                "@babel/generator": "^7.24.5",
                 "@babel/helper-compilation-targets": "^7.23.6",
-                "@babel/helper-module-transforms": "^7.23.3",
-                "@babel/helpers": "^7.24.1",
-                "@babel/parser": "^7.24.1",
+                "@babel/helper-module-transforms": "^7.24.5",
+                "@babel/helpers": "^7.24.5",
+                "@babel/parser": "^7.24.5",
                 "@babel/template": "^7.24.0",
-                "@babel/traverse": "^7.24.1",
-                "@babel/types": "^7.24.0",
+                "@babel/traverse": "^7.24.5",
+                "@babel/types": "^7.24.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -2061,30 +2057,30 @@
             }
         },
         "node_modules/@lwc/engine-dom": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@lwc/engine-dom/-/engine-dom-6.5.0.tgz",
-            "integrity": "sha512-BnW69DPT/Ct74G0ATAEyEE5Y1JxHnAfFQBEvE0ILdGENWJ+Uc25q+e0OiIIoAgWUlp2pAxXb9C2LgYXde3kpIg==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@lwc/engine-dom/-/engine-dom-6.7.2.tgz",
+            "integrity": "sha512-NF07hR2QJGonssuzW77YF2G1RxjKvARi6lqv+PUKg6uSv97jm/lQO3r1pKPnrVeH456aFj0lLG+JStM0nhdKWg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@lwc/engine-server": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@lwc/engine-server/-/engine-server-6.5.0.tgz",
-            "integrity": "sha512-6S1GNsL0uBQRLq7u9bYnpN+taqDLkFb9SmaVQwN0RTRHjxY2Flx4yd0ebu+LqCjd6DcCm4DidsbUC8GsR5iBfg==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@lwc/engine-server/-/engine-server-6.7.2.tgz",
+            "integrity": "sha512-ibPaEShA39NbVjIDegi4XnaHmmbCfdzeR5H6Cqeq8SfrKOaRPreway1dwLb+ULTT/tufgvgU/WvvX0XxHPJYXQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@lwc/errors": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-6.5.0.tgz",
-            "integrity": "sha512-hbtrIz86IAfmZ+qSa/LPOrPsirHIncotfSfgZoBb+u7q9bqlzUmoKmNKPaNvwtjQSARnCqPa+4DrFUXIGHW7gA==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@lwc/errors/-/errors-6.7.2.tgz",
+            "integrity": "sha512-X6hs8F7x8/jX+wU+1sWv5AROPCsQmvEPb9ejsGBt4/4+oI+5QTTtBR0q7MktP2YenXTjd1xl0uQR0pjo3nlFHw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@lwc/eslint-plugin-lwc": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-1.8.1.tgz",
-            "integrity": "sha512-xtBvjT2Cxp20Vj/o+b7YeIJkAFXlZow90DoJGjqEyRxPb6pmWSZ3FzcrffSUOacETJey01UiA29rquRftJiH8A==",
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-1.8.2.tgz",
+            "integrity": "sha512-kPlOq6G2BPo3x56qkGOgwas1SJWZYeQR6uXLMFzFrjb/Lisb24VeABNQd1i7JgoQXQzad0F12pfU0BLgIhhR7g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2129,15 +2125,15 @@
             }
         },
         "node_modules/@lwc/jest-preset": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-preset/-/jest-preset-15.0.0.tgz",
-            "integrity": "sha512-qwLO9d5WEpG3GTJ4TLmkN53FBZHUlyxr4At6/qsWtv7NXPzVJVxFRdFZDgW+sut2TIfbpD5Ptg3Ex7a+5ul1pA==",
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-preset/-/jest-preset-16.0.0.tgz",
+            "integrity": "sha512-3mBI3HzU+0KvDSTWAhcSpX139gkyzmCIpsJb67x/Jwm2en4+3q8i5/aCc7I2QJwIw/25T2LJUcDbz4Z5zD3VDw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@lwc/jest-resolver": "15.0.0",
-                "@lwc/jest-serializer": "15.0.0",
-                "@lwc/jest-transformer": "15.0.0"
+                "@lwc/jest-resolver": "16.0.0",
+                "@lwc/jest-serializer": "16.0.0",
+                "@lwc/jest-transformer": "16.0.0"
             },
             "engines": {
                 "node": ">=10"
@@ -2151,13 +2147,13 @@
             }
         },
         "node_modules/@lwc/jest-resolver": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-resolver/-/jest-resolver-15.0.0.tgz",
-            "integrity": "sha512-vCZfo1ybbYrALlRI3lZc4tbvFq5XsmVT214CVCTUoQ9QzJpiEZwCefULywpX2sW0xoqp89AXuLzeHdek6gSE4Q==",
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-resolver/-/jest-resolver-16.0.0.tgz",
+            "integrity": "sha512-REEN9cBHdppEcC0yYmCS9AmFiBPOFiH6VAfR5IbggfL4ykF2D90oE6p35oFSWZV7fqFBeWuc2jxAmE/bv/Dl1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@lwc/jest-shared": "15.0.0"
+                "@lwc/jest-shared": "16.0.0"
             },
             "engines": {
                 "node": ">=10"
@@ -2167,13 +2163,13 @@
             }
         },
         "node_modules/@lwc/jest-serializer": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-serializer/-/jest-serializer-15.0.0.tgz",
-            "integrity": "sha512-d4cqeiG58h9wuQnA3XvtUcUOmJw8VOBxL4MpsWdABA35rN7Wt5BFWm4mEOZ3L+pnIO7J0Eo9JdZ1w88hJLNjVQ==",
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-serializer/-/jest-serializer-16.0.0.tgz",
+            "integrity": "sha512-VDVnsxBpS+WwviNieH4bZzq+N0EMdAM3RCbc4L9d4HbSOF8slD/kdsTXkhcaDW6hCXP8TKztMPNTvOzY+qH9+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@lwc/jest-shared": "15.0.0",
+                "@lwc/jest-shared": "16.0.0",
                 "pretty-format": "^29.7.0"
             },
             "engines": {
@@ -2184,9 +2180,9 @@
             }
         },
         "node_modules/@lwc/jest-shared": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-shared/-/jest-shared-15.0.0.tgz",
-            "integrity": "sha512-RUlT789k4xH9NYJsB5uvVo6c+EY5pwrly5aOQje6+jQBHWcBPp7Z/vQFDM/gvft4pmHjyniqR6XCFaJ/BJ702g==",
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-shared/-/jest-shared-16.0.0.tgz",
+            "integrity": "sha512-S1LiCi2ToC20va1KBcuWqH3Bm9t96k2inVCeGN96+Q4sZSrebBHwfyBEBKq75uwph7FbhHmYv7chLPDZUQIoVg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2194,9 +2190,9 @@
             }
         },
         "node_modules/@lwc/jest-transformer": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/@lwc/jest-transformer/-/jest-transformer-15.0.0.tgz",
-            "integrity": "sha512-ZsP8eytxZYt5zR6ysLmREiArpmeTUAoom22RbNdiIHytYcC2AcrZWrwju0VleMxJ1pVVkB3xE9nOlGOywdFf1Q==",
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/@lwc/jest-transformer/-/jest-transformer-16.0.0.tgz",
+            "integrity": "sha512-//iiLVPdaOnzg/HN8mox+xeSKmebzVervoaJWhvmICIDagtZz9S88dSVsnFKsnY03yOLA7XM8Wz/11ZaZ8bhUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2206,7 +2202,7 @@
                 "@babel/plugin-syntax-decorators": "^7.24.0",
                 "@babel/plugin-transform-modules-commonjs": "^7.23.3",
                 "@babel/preset-typescript": "^7.23.3",
-                "@lwc/jest-shared": "15.0.0",
+                "@lwc/jest-shared": "16.0.0",
                 "babel-preset-jest": "^29.6.3",
                 "magic-string": "^0.30.8",
                 "semver": "^7.6.0"
@@ -2233,9 +2229,9 @@
             }
         },
         "node_modules/@lwc/module-resolver": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@lwc/module-resolver/-/module-resolver-6.5.0.tgz",
-            "integrity": "sha512-bgxCdRygdDQjM9q9r43U5O+qDnod7XiNye8KmAItfogsOE8j278A3BobF6a3sgG9qifpE0IhAQeNw1mejBPXsg==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@lwc/module-resolver/-/module-resolver-6.7.2.tgz",
+            "integrity": "sha512-wm9BqWrz/Q1G7RC4/Sz5BpVLJn1qw0Bu2zFsc7Dz23J8nfziRTfNs2Fv8PMA9SrJ3BsYMDjIZOiv3Ip5CSPCJg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2243,51 +2239,65 @@
             }
         },
         "node_modules/@lwc/shared": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@lwc/shared/-/shared-6.5.0.tgz",
-            "integrity": "sha512-GkModrLxc7LYZ8Kh9adGwKZHpzlpceCpNlfQPcVvB9EdmOuQVwNwU7+DW3+wFdTm2DdAD8uToSftBsuT4gLwTw==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@lwc/shared/-/shared-6.7.2.tgz",
+            "integrity": "sha512-wNl4NOEgqgl00MdJWCG3zGj4cLRaDf0kXEgfklpBqoQD1j9ob9eT1Z0eb1GKUdF6uWAw9DBBYRzztT0KMP6+/Q==",
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@lwc/style-compiler": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@lwc/style-compiler/-/style-compiler-6.5.0.tgz",
-            "integrity": "sha512-PCxU6IeXLhNoj/de1kzjzOo8SECZLHJ30TrLx50ISwCIr2XfZ7Ay0hItNtZuxj4j+1cZ285SU+eq22hAJCptoQ==",
+        "node_modules/@lwc/ssr-compiler": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@lwc/ssr-compiler/-/ssr-compiler-6.7.2.tgz",
+            "integrity": "sha512-6ME+ztoybT6G3N3aCSk4qXSduMk3EdbesAbG20f0CEYWNKt2lwpa9DNq6FViZSL6227u09Bh/a9oOJaWm+kbDg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@lwc/shared": "6.5.0",
-                "postcss": "~8.4.37",
+                "@lwc/template-compiler": "6.7.2",
+                "acorn": "8.11.3",
+                "astring": "^1.8.6",
+                "estree-toolkit": "^1.7.5",
+                "immer": "^10.1.1",
+                "meriyah": "^4.3.8"
+            }
+        },
+        "node_modules/@lwc/style-compiler": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@lwc/style-compiler/-/style-compiler-6.7.2.tgz",
+            "integrity": "sha512-sl48VTWbWa4b+97z9YWmhPrw5UkIYHgXJSwZJs9H2O3hiZr5xhbAPn7kXN9tdBousT5YqXq76+SdCyvi8jhLGg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@lwc/shared": "6.7.2",
+                "postcss": "~8.4.38",
                 "postcss-selector-parser": "~6.0.15",
                 "postcss-value-parser": "~4.2.0"
             }
         },
         "node_modules/@lwc/synthetic-shadow": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@lwc/synthetic-shadow/-/synthetic-shadow-6.5.0.tgz",
-            "integrity": "sha512-0Xn+q0QwTI5DaOawHA9E+/QXTz2+DhOTqcfmYFENPvuqDLnETyiWnnbu9bFoBUMgh1U6eyBN+3sco69oL6xY5Q==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@lwc/synthetic-shadow/-/synthetic-shadow-6.7.2.tgz",
+            "integrity": "sha512-nJRUggEX2wpuoPFzlQldYEYIS7keukS0se30jXZ8XznMJSSxjapaZw1LZCogLZpdHFj9TY1rwOuHrQclixZtIw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@lwc/template-compiler": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-6.5.0.tgz",
-            "integrity": "sha512-n6zQOatVzjxN1PHmErvN2VoQY9XzPTSh+j5CgzXQlu0bdEU5/KGFMQF3jN8aUvHK49o++t91Q8BN1cKkPcG62g==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@lwc/template-compiler/-/template-compiler-6.7.2.tgz",
+            "integrity": "sha512-Te3RL/1p8LLsCj9xrSmMTBuCWkc+G23wlPmxzZ+TFhXFTJ12JWQlOP8cKzMDVJ1XjHRH3ptgT87C/0v9NuA7Og==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@lwc/errors": "6.5.0",
-                "@lwc/shared": "6.5.0",
-                "acorn": "8.10.0",
+                "@lwc/errors": "6.7.2",
+                "@lwc/shared": "6.7.2",
+                "acorn": "~8.11.3",
                 "astring": "~1.8.6",
-                "estree-walker": "~2.0.2",
                 "he": "~1.2.0"
             }
         },
         "node_modules/@lwc/wire-service": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@lwc/wire-service/-/wire-service-6.5.0.tgz",
-            "integrity": "sha512-mKkqDyR7DRxEqjDX3rl8jEod13CJX7WNf3uOuq6sqacYTZhD6uADypLUOwlalAkucy3b88JuLrQ9IyPluwswUQ==",
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@lwc/wire-service/-/wire-service-6.7.2.tgz",
+            "integrity": "sha512-foDQbvpvNzhMpS7KPNbKK+aI8BeLR1omDNgEDwo7NJPddiqbOSybQCcYgk0YXSQ0th2xrE4Tat5YF4wqmhVZdQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -2353,16 +2363,16 @@
             }
         },
         "node_modules/@salesforce/eslint-config-lwc": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/@salesforce/eslint-config-lwc/-/eslint-config-lwc-3.5.3.tgz",
-            "integrity": "sha512-bQ3EdqDQadG18a19Aw7VD6iS5YPuQXNPjfvR/bOFzu1DZoctW5lq28gSMueRLoYjBW+dDa2V8gUWQNmj+b0JUQ==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/@salesforce/eslint-config-lwc/-/eslint-config-lwc-3.6.0.tgz",
+            "integrity": "sha512-k6F3LFKl6wvAmK31B/jn8aHtqo+kwl5q96DzhIcmL1qnCZj+AzH5gw9034j+c8279d8u8dC5QIUDU1iE3aCNCg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/core": "~7.22.8",
-                "@babel/eslint-parser": "~7.22.7",
+                "@babel/core": "~7.24.7",
+                "@babel/eslint-parser": "~7.24.7",
                 "eslint-restricted-globals": "~0.2.0",
-                "semver": "^7.5.3"
+                "semver": "^7.6.2"
             },
             "engines": {
                 "node": ">=10.0.0"
@@ -2374,83 +2384,6 @@
                 "eslint-plugin-import": "*",
                 "eslint-plugin-jest": "*"
             }
-        },
-        "node_modules/@salesforce/eslint-config-lwc/node_modules/@babel/core": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.20.tgz",
-            "integrity": "sha512-Y6jd1ahLubuYweD/zJH+vvOY141v4f9igNQAQ+MBgq9JlHS2iTsZKn1aMsb3vGccZsXI16VzTBw52Xx0DWmtnA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.22.13",
-                "@babel/generator": "^7.22.15",
-                "@babel/helper-compilation-targets": "^7.22.15",
-                "@babel/helper-module-transforms": "^7.22.20",
-                "@babel/helpers": "^7.22.15",
-                "@babel/parser": "^7.22.16",
-                "@babel/template": "^7.22.15",
-                "@babel/traverse": "^7.22.20",
-                "@babel/types": "^7.22.19",
-                "convert-source-map": "^1.7.0",
-                "debug": "^4.1.0",
-                "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.3",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/babel"
-            }
-        },
-        "node_modules/@salesforce/eslint-config-lwc/node_modules/@babel/core/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@salesforce/eslint-config-lwc/node_modules/@babel/eslint-parser": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.15.tgz",
-            "integrity": "sha512-yc8OOBIQk1EcRrpizuARSQS0TWAcOMpEJ1aafhNznaeYkeL+OhqnDObGFylB8ka8VFF/sZc+S4RzHyO+3LjQxg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-                "eslint-visitor-keys": "^2.1.0",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.11.0",
-                "eslint": "^7.5.0 || ^8.0.0"
-            }
-        },
-        "node_modules/@salesforce/eslint-config-lwc/node_modules/@babel/eslint-parser/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@salesforce/eslint-config-lwc/node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@salesforce/eslint-config-lwc/node_modules/semver": {
             "version": "7.6.2",
@@ -2476,22 +2409,22 @@
             }
         },
         "node_modules/@salesforce/sfdx-lwc-jest": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@salesforce/sfdx-lwc-jest/-/sfdx-lwc-jest-5.0.0.tgz",
-            "integrity": "sha512-41Er5QNQD3/na092h8qZBmA96TjU7fwCzneYCLzmCKy//29CAgGLkXmw9eX1qzZNYTsbbkAA08edcxHgT5BBFQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@salesforce/sfdx-lwc-jest/-/sfdx-lwc-jest-5.1.0.tgz",
+            "integrity": "sha512-jz8Zxn7ZNrDkf2T0MdzeQ+tXAxLuRTPPC41m3Clo6caTsm5vOGcbHn8KtkhyafDvuhDU1eGGBneMdDAmku+zpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@lwc/compiler": "6.5.0",
-                "@lwc/engine-dom": "6.5.0",
-                "@lwc/engine-server": "6.5.0",
-                "@lwc/jest-preset": "15.0.0",
-                "@lwc/jest-resolver": "15.0.0",
-                "@lwc/jest-serializer": "15.0.0",
-                "@lwc/jest-transformer": "15.0.0",
-                "@lwc/module-resolver": "6.5.0",
-                "@lwc/synthetic-shadow": "6.5.0",
-                "@lwc/wire-service": "6.5.0",
+                "@lwc/compiler": "6.7.2",
+                "@lwc/engine-dom": "6.7.2",
+                "@lwc/engine-server": "6.7.2",
+                "@lwc/jest-preset": "16.0.0",
+                "@lwc/jest-resolver": "16.0.0",
+                "@lwc/jest-serializer": "16.0.0",
+                "@lwc/jest-transformer": "16.0.0",
+                "@lwc/module-resolver": "6.7.2",
+                "@lwc/synthetic-shadow": "6.7.2",
+                "@lwc/wire-service": "6.7.2",
                 "@salesforce/wire-service-jest-util": "4.1.4",
                 "fast-glob": "^3.3.2",
                 "jest": "29.7.0",
@@ -2624,6 +2557,23 @@
                 "@babel/types": "^7.20.7"
             }
         },
+        "node_modules/@types/estree": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/estree-jsx": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+            "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*"
+            }
+        },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.9",
             "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -2699,9 +2649,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "20.14.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
-            "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+            "version": "20.14.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+            "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3038,9 +2988,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/acorn": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-            "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -3072,11 +3022,14 @@
             }
         },
         "node_modules/acorn-walk": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-            "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+            "version": "8.3.3",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
+            "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.11.0"
+            },
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -3656,9 +3609,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001633",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001633.tgz",
-            "integrity": "sha512-6sT0yf/z5jqf8tISAgpJDrmwOpLsrpnyCdD/lOZKvKkkJK4Dn0X5i7KF7THEZhOq+30bmhwBlNEaqPUiHiKtZg==",
+            "version": "1.0.30001640",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz",
+            "integrity": "sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA==",
             "dev": true,
             "funding": [
                 {
@@ -4333,9 +4286,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.801",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.801.tgz",
-            "integrity": "sha512-PnlUz15ii38MZMD2/CEsAzyee8tv9vFntX5nhtd2/4tv4HqY7C5q2faUAjmkXS/UFpVooJ/5H6kayRKYWoGMXQ==",
+            "version": "1.4.820",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.820.tgz",
+            "integrity": "sha512-kK/4O/YunacfboFEk/BDf7VO1HoPmDudLTJAU9NmXIOSjsV7qVIX3OrI4REZo0VmdqhcpUcncQc6N8Q3aEXlHg==",
             "dev": true,
             "license": "ISC"
         },
@@ -5044,9 +4997,9 @@
             }
         },
         "node_modules/esquery": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-            "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+            "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -5099,12 +5052,16 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+        "node_modules/estree-toolkit": {
+            "version": "1.7.5",
+            "resolved": "https://registry.npmjs.org/estree-toolkit/-/estree-toolkit-1.7.5.tgz",
+            "integrity": "sha512-e26HrVkoOZMKEyNkF107NyJkGNSmOi9ageC4/sR7zR0HcyOw9+U+Nnvuzl4ufbTHmEhvA75yh6C8XnWHomD5sg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.5",
+                "@types/estree-jsx": "^1.0.5"
+            }
         },
         "node_modules/esutils": {
             "version": "2.0.3",
@@ -5840,6 +5797,17 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immer": {
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+            "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -5989,13 +5957,16 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.13.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-            "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
+            "integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "hasown": "^2.0.0"
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -6280,9 +6251,9 @@
             }
         },
         "node_modules/istanbul-lib-instrument": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.2.tgz",
-            "integrity": "sha512-1WUsZ9R1lA0HtBSohTkm39WTPlNKSJ5iFk7UwqXkBLoHQT+hfqPsfsTDVuZdKGaBwn7din9bS7SsnoAr943hvw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+            "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -8075,9 +8046,9 @@
             }
         },
         "node_modules/joi": {
-            "version": "17.13.1",
-            "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.1.tgz",
-            "integrity": "sha512-vaBlIKCyo4FCUtCm7Eu4QZd/q02bWcxfUO6YSXAZOWF6gzcLBeba8kwotUdYJjDLW8Cz8RywsSOqiNJZW0mNvg==",
+            "version": "17.13.3",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+            "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -8469,9 +8440,9 @@
             }
         },
         "node_modules/listr2": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.2.1.tgz",
-            "integrity": "sha512-irTfvpib/rNiD637xeevjO2l3Z5loZmuaRi0L0YE5LfijwVY96oyVn0DFD3o/teAok7nfobMG1THvvcHh/BP6g==",
+            "version": "8.2.3",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.2.3.tgz",
+            "integrity": "sha512-Lllokma2mtoniUOS94CcOErHWAug5iu7HOmDrvWgpw8jyQH2fomgB+7lZS4HWZxytUuQwkGOwe49FvwVaA85Xw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8479,7 +8450,7 @@
                 "colorette": "^2.0.20",
                 "eventemitter3": "^5.0.1",
                 "log-update": "^6.0.0",
-                "rfdc": "^1.3.1",
+                "rfdc": "^1.4.1",
                 "wrap-ansi": "^9.0.0"
             },
             "engines": {
@@ -8707,6 +8678,16 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/meriyah": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-4.5.0.tgz",
+            "integrity": "sha512-Rbiu0QPIxTXgOXwiIpRVJfZRQ2FWyfzYrOGBs9SN5RbaXg1CN5ELn/plodwWwluX93yzc4qO/bNIen1ThGFCxw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10.4.0"
+            }
+        },
         "node_modules/micromatch": {
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
@@ -8755,9 +8736,9 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "9.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-            "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -8858,11 +8839,14 @@
             "license": "MIT"
         },
         "node_modules/object-inspect": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+            "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -9249,9 +9233,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.38",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-            "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+            "version": "8.4.39",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
+            "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
             "dev": true,
             "funding": [
                 {
@@ -9270,7 +9254,7 @@
             "license": "MIT",
             "dependencies": {
                 "nanoid": "^3.3.7",
-                "picocolors": "^1.0.0",
+                "picocolors": "^1.0.1",
                 "source-map-js": "^1.2.0"
             },
             "engines": {
@@ -9943,9 +9927,9 @@
             }
         },
         "node_modules/string-width": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
-            "integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10395,9 +10379,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.4.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-            "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+            "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
             "dev": true,
             "license": "Apache-2.0",
             "peer": true,
@@ -10443,9 +10427,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-            "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+            "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
             "dev": true,
             "funding": [
                 {
@@ -10502,9 +10486,9 @@
             "license": "MIT"
         },
         "node_modules/v8-to-istanbul": {
-            "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
-            "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+            "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -10751,9 +10735,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-            "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
         "prepare": "husky"
     },
     "devDependencies": {
-        "@lwc/eslint-plugin-lwc": "^1.8.1",
+        "@lwc/eslint-plugin-lwc": "^1.8.2",
         "@prettier/plugin-xml": "^3.4.1",
-        "@salesforce/eslint-config-lwc": "^3.5.3",
+        "@salesforce/eslint-config-lwc": "^3.6.0",
         "@salesforce/eslint-plugin-lightning": "^1.0.0",
-        "@salesforce/sfdx-lwc-jest": "^5.0.0",
+        "@salesforce/sfdx-lwc-jest": "^5.1.0",
         "eslint": "^8.57.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jest": "^28.6.0",

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,5 +9,5 @@
     "name": "sticky-selectron",
     "namespace": "",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "59.0"
+    "sourceApiVersion": "61.0"
 }

--- a/unpackaged/config/example-flows/flows/Sticky_Selectron_Example_Accounts_Flow.flow-meta.xml
+++ b/unpackaged/config/example-flows/flows/Sticky_Selectron_Example_Accounts_Flow.flow-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>60.0</apiVersion>
+    <apiVersion>61.0</apiVersion>
     <assignments>
         <name>Set_Input_Table_Field_Names</name>
         <label>Set Input Table Field Names</label>


### PR DESCRIPTION

# Critical Changes

# Changes

- Bump from API v60.0 to API v61.0
- Bump devDependencies
  - @lwc/eslint-plugin-lwc from 1.8.1 to 1.8.2
  - @salesforce/eslint-config-lwc from 3.5.3 to 3.6.0
  - @salesforce/sfdx-lwc-jest from 5.0.0 to 5.1.0

# Issues Closed
