### PR TITLE
Fix LWC getFieldLabels params to match case expected by Apex

### DIFF
--- a/force-app/main/default/lwc/stickySelectronMain/stickySelectronMain.js
+++ b/force-app/main/default/lwc/stickySelectronMain/stickySelectronMain.js
@@ -107,7 +107,7 @@ export default class StickySelectronMain extends LightningElement {
                     try {
                         const fieldLabel = await getFieldLabels({
                             objectName: sObjectType,
-                            fieldAPIName: inputTableFieldName
+                            fieldApiName: inputTableFieldName
                         });
                         this.fieldsOnLeft.push({
                             label: fieldLabel,
@@ -142,7 +142,7 @@ export default class StickySelectronMain extends LightningElement {
                     try {
                         const fieldLabel = await getFieldLabels({
                             objectName: sObjectType,
-                            fieldAPIName: selectedTableFieldName
+                            fieldApiName: selectedTableFieldName
                         });
                         this.fieldsOnRight.push({
                             label: fieldLabel,


### PR DESCRIPTION

# Critical Changes
- Without this fix, the LWC cannot pass fieldNames to Apex

# Changes

# Issues Closed
