### PR TITLE
Fix percentage formatting between Apex and JS

### DIFF
--- a/force-app/main/default/lwc/stickySelectronDataCell/stickySelectronDataCell.js
+++ b/force-app/main/default/lwc/stickySelectronDataCell/stickySelectronDataCell.js
@@ -90,7 +90,7 @@ export default class StickySelectronDataCell extends LightningElement {
                 return formatCurrencyLocale(inputVal);
             }
             if (this.sfType === 'PERCENT') {
-                return formatPercentLocale(inputVal);
+                return formatPercentLocale(inputVal / 100);
             }
             if (this.sfType === 'DOUBLE') {
                 return formatDoubleLocale(inputVal, this.sfScale);


### PR DESCRIPTION

# Critical Changes

# Changes
- Javascript percentage formatting was showing a number multiplied by 100 - this PR fixes it

# Issues Closed
