### PR TITLE
Make sure that 0 percent, currency, and doubles still get formatting symbols

### DIFF
--- a/force-app/main/default/lwc/stickySelectronDataCell/stickySelectronDataCell.js
+++ b/force-app/main/default/lwc/stickySelectronDataCell/stickySelectronDataCell.js
@@ -70,7 +70,13 @@ export default class StickySelectronDataCell extends LightningElement {
 
     get fieldValForObject() {
         const inputVal = this.object?.[this.fieldName];
-        if (inputVal) {
+        // We may get a zero value from Apex that should still be rendered with our JS formatting
+        if (
+            inputVal ||
+            this.sfType === 'CURRENCY' ||
+            this.sfType === 'PERCENT' ||
+            this.sfType === 'DOUBLE'
+        ) {
             if (this.sfType === 'DATETIME') {
                 const hasDate = true;
                 const hasTime = true;


### PR DESCRIPTION

# Critical Changes

# Changes
- 0 percent, currency, and doubles still get formatting symbols (JS and Apex transfer 0 on the wire)

# Issues Closed
