### PR TITLE
Update JS loader icon based on Apex and records load completion

### DIFF
--- a/force-app/main/default/lwc/stickySelectronMain/stickySelectronMain.html
+++ b/force-app/main/default/lwc/stickySelectronMain/stickySelectronMain.html
@@ -58,7 +58,7 @@
                     class="slds-float_left slds-var-m-top_xx-small slds-var-p-around_x-small slds-scrollable_y grid-main"
                 >
                     <!-- Spinner -->
-                    <template if:true={isLoading}>
+                    <template if:true={stillShowLoading}>
                         <div class="slds-var-p-around_x-large spinner">
                             <lightning-spinner
                                 alternative-text="Loading"

--- a/force-app/main/default/lwc/stickySelectronMain/stickySelectronMain.js
+++ b/force-app/main/default/lwc/stickySelectronMain/stickySelectronMain.js
@@ -36,6 +36,18 @@ export default class StickySelectronMain extends LightningElement {
     @api initialListCount;
     isLoading = false;
 
+    // We want to continue showing the loading icon if our LWC hasn't rendered yet,
+    // if the input list is empty, or if the input table field metadata hasn't finished yet
+    // Note that we compare the inputTableFieldNames length to the fieldsOnLeft length - 1 because of the Select column that is in the fieldsOnLeft but
+    // not in the inputTableFieldNames
+    get stillShowLoading() {
+        return (
+            this.isLoading ||
+            this.workingInputObjList.length === 0 ||
+            this.inputTableFieldNames.length !== this.fieldsOnLeft.length - 1
+        );
+    }
+
     @api inputTableFieldNames;
     @api selectedTableFieldNames;
 


### PR DESCRIPTION




# Critical Changes

# Changes
- Add helper function to determine when we should show the loading icon based on LWC render, data from flow loaded, and metadata about fields

# Issues Closed
- https://github.com/SFDO-Community/sticky-selectron/issues/55
