### PR TITLE
Feature/fix dev metadata and loading search

### DIFF
--- a/unpackaged/config/dev/flows/Sticky_Selectron_Example_Accounts_Flow.flow-meta.xml
+++ b/unpackaged/config/dev/flows/Sticky_Selectron_Example_Accounts_Flow.flow-meta.xml
@@ -123,7 +123,6 @@
         <queriedFields>ssCurrency__c</queriedFields>
         <queriedFields>ssDateTime__c</queriedFields>
         <queriedFields>AnnualRevenue</queriedFields>
-        <queriedFields>NewCurrency__c</queriedFields>
         <queriedFields>CreatedDate</queriedFields>
     </recordLookups>
     <screens>

--- a/unpackaged/config/dev/layouts/Account-Account %28Marketing%29 Layout.layout-meta.xml
+++ b/unpackaged/config/dev/layouts/Account-Account %28Marketing%29 Layout.layout-meta.xml
@@ -31,7 +31,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>NewCurrency__c</field>
+                <field>ssCurrency__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -40,6 +40,10 @@
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>ssDate__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>ssDateTime__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>

--- a/unpackaged/config/dev/layouts/Account-Account %28Sales%29 Layout.layout-meta.xml
+++ b/unpackaged/config/dev/layouts/Account-Account %28Sales%29 Layout.layout-meta.xml
@@ -47,10 +47,6 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>NewCurrency__c</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
                 <field>ssDouble__c</field>
             </layoutItems>
             <layoutItems>

--- a/unpackaged/config/dev/layouts/Account-Account %28Support%29 Layout.layout-meta.xml
+++ b/unpackaged/config/dev/layouts/Account-Account %28Support%29 Layout.layout-meta.xml
@@ -43,7 +43,7 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>NewCurrency__c</field>
+                <field>ssCurrency__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -52,6 +52,10 @@
             <layoutItems>
                 <behavior>Edit</behavior>
                 <field>ssDate__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>ssDateTime__c</field>
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>

--- a/unpackaged/config/dev/layouts/Account-Account Layout.layout-meta.xml
+++ b/unpackaged/config/dev/layouts/Account-Account Layout.layout-meta.xml
@@ -43,10 +43,6 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
-                <field>NewCurrency__c</field>
-            </layoutItems>
-            <layoutItems>
-                <behavior>Edit</behavior>
                 <field>ssDouble__c</field>
             </layoutItems>
             <layoutItems>

--- a/unpackaged/config/dev/objects/Account/fields/ssDateTime__c.field-meta.xml
+++ b/unpackaged/config/dev/objects/Account/fields/ssDateTime__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ssDateTime__c</fullName>
+    <description>Help field for sticky selectron dev</description>
+    <label>ssDateTime</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>DateTime</type>
+</CustomField>


### PR DESCRIPTION

# Critical Changes
- Fix the loading logic to not show the spinner if a search returns no results
- Add some filtering in the search logic to exclude special characters that would show up in the html but not the numeric values (like `$`,`,`,`%`)

# Changes

# Issues Closed
- https://github.com/SFDO-Community/sticky-selectron/issues/57